### PR TITLE
ca証明書をコピーしてくる

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@ FROM scratch
 
 WORKDIR /app
 COPY --from=builder /src/bin/ecr-lifecycle /app/
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
 ENTRYPOINT ["./ecr-lifecycle"]


### PR DESCRIPTION
# what

Goをビルドするイメージから証明書をコピーしてきた
<https://qiita.com/_mkazutaka/items/12f8d560e163b8ab1813>

# why

ECSのdocker環境で動かそうとしたらこんなエラーが出た。

```
RequestError: send request failed
caused by: Post https://api.ecr.ap-northeast-1.amazonaws.com/: x509: certificate signed by unknown authority
```

ECRにアクセスしようとしたらSSL証明書がなくてエラーになってるようだった。
