### PR TITLE
取得してきたイメージを最新順に並び替える

### DIFF
--- a/ecs/task.go
+++ b/ecs/task.go
@@ -34,7 +34,7 @@ func (c *Client) ListAllRunningTasks() ([]Task, error) {
 			return nil, err
 		}
 
-		// タスク詳細を元にtaskDefintionを取得
+		// タスク詳細を元にtaskDefinitionを取得
 		for _, taskOutput := range tasksOutput.Tasks {
 			taskDefinition, err := c.describeTaskDefinition(taskOutput.TaskDefinitionArn)
 			if err != nil {


### PR DESCRIPTION
# why

latestのイメージが削除されてしまうケースがあった。  
最新n件は保持し、nを超えた場合のみ現在実行中かどうかを判定したいため、最新順であることを保証する。