### PR TITLE
全てのprofileで実行されているタスクを一つのsliceにぶち込んでから削除可否判定をする

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -61,18 +61,17 @@ var cmdDeleteImages = cli.Command{
 					<-semaphore
 					defer wg.Done()
 				}()
-				for _, c := range config.ecsClients {
-					result, err := config.ecrClient.BatchDeleteImages(r, config.flag.keep, c)
-					if err != nil {
-						log.sugar.Warnf("could not delete images: %s", err)
+
+				result, err := config.ecrClient.BatchDeleteImages(r, config.flag.keep, config.ecsClients)
+				if err != nil {
+					log.sugar.Warnf("could not delete images: %s", err)
+				}
+				if result != nil {
+					for _, f := range result.Failures {
+						log.sugar.Warnw("warn", "FailureCode", f.FailureCode, "FailureReason", f.FailureReason, "ImageId", f.ImageId)
 					}
-					if result != nil {
-						for _, f := range result.Failures {
-							log.sugar.Warnw("warn", "FailureCode", f.FailureCode, "FailureReason", f.FailureReason, "ImageId", f.ImageId)
-						}
-						for _, id := range result.ImageIds {
-							log.sugar.Infow("deletedImageId", "RepositoryName", r.Detail.RepositoryName, "ImageDigest", id.ImageDigest)
-						}
+					for _, id := range result.ImageIds {
+						log.sugar.Infow("deletedImageId", "RepositoryName", r.Detail.RepositoryName, "ImageDigest", id.ImageDigest)
 					}
 				}
 			}(repo)

--- a/ecr/image.go
+++ b/ecr/image.go
@@ -118,10 +118,10 @@ func (c *Client) BatchGetImages(r ecr.Repository) ([]*Image, error) {
 	return sortedImages, nil
 }
 
-// sortImages ... ImagePushedAtの降順になるようにソートする
+// sortImages ... ImagePushedAtが最新のものから降順になるようにソートする
 func sortImages(images []*Image) []*Image {
 	sort.SliceStable(images, func(i, j int) bool {
-		return images[i].Detail.ImagePushedAt.Before(*images[j].Detail.ImagePushedAt)
+		return images[i].Detail.ImagePushedAt.After(*images[j].Detail.ImagePushedAt)
 	})
 
 	return images

--- a/ecr/image.go
+++ b/ecr/image.go
@@ -29,8 +29,8 @@ func (i *Image) Uris(r ecr.Repository) []string {
 }
 
 // BatchDeleteImages ... 指定したrepositoryのimageを削除する。
-func (c *Client) BatchDeleteImages(r Repository, imageCountMoreThan int, ecs ecs.Client) (*ecr.BatchDeleteImageOutput, error) {
-	input, err := c.BatchDeleteImageInput(*r.Detail, imageCountMoreThan, ecs)
+func (c *Client) BatchDeleteImages(r Repository, imageCountMoreThan int, ecsClients []ecs.Client) (*ecr.BatchDeleteImageOutput, error) {
+	input, err := c.BatchDeleteImageInput(*r.Detail, imageCountMoreThan, ecsClients)
 	if err != nil {
 		return nil, err
 	}
@@ -49,20 +49,27 @@ func (c *Client) BatchDeleteImages(r Repository, imageCountMoreThan int, ecs ecs
 }
 
 // BatchDeleteImageInput ... DeleteするImageを絞り込む。
-func (c *Client) BatchDeleteImageInput(r ecr.Repository, imageCountMoreThan int, ecs ecs.Client) (*ecr.BatchDeleteImageInput, error) {
+func (c *Client) BatchDeleteImageInput(r ecr.Repository, imageCountMoreThan int, ecsClients []ecs.Client) (*ecr.BatchDeleteImageInput, error) {
 	images, err := c.BatchGetImages(r)
 	if err != nil {
 		return nil, err
 	}
 
-	runningTasks, err := ecs.ListAllRunningTasks()
-	if err != nil {
-		return nil, err
+	var runningTasks []ecs.Task
+
+	for _, client := range ecsClients {
+		tasks, err := client.ListAllRunningTasks()
+		if err != nil {
+			return nil, err
+		}
+
+		runningTasks = append(runningTasks, tasks...)
 	}
 
 	var imageIds []*ecr.ImageIdentifier
 
 	for i, image := range images {
+		// iは0から始まるため `<=` じゃなくてよい
 		if i < imageCountMoreThan {
 			continue
 		}

--- a/ecr/image_test.go
+++ b/ecr/image_test.go
@@ -165,7 +165,7 @@ func Test_sortImages(t *testing.T) {
 			want: []*Image{
 				{
 					Detail: &ecr.ImageDetail{
-						ImagePushedAt: strToTime("2020-01-31"),
+						ImagePushedAt: strToTime("2020-02-02"),
 					},
 				},
 				{
@@ -175,7 +175,7 @@ func Test_sortImages(t *testing.T) {
 				},
 				{
 					Detail: &ecr.ImageDetail{
-						ImagePushedAt: strToTime("2020-02-02"),
+						ImagePushedAt: strToTime("2020-01-31"),
 					},
 				},
 			},


### PR DESCRIPTION
# why

呼び出し側でECSClientsでfor文を回してdeleteしていたため、最初のECSClientで実行されているものがなければ消されてしまう問題があった。
全部の実行されているタスクを集約してから判定していく。